### PR TITLE
Updated README to point to correct location

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Example Playbook
 ----------------
     - hosts: servers
       roles:
-         - role: telusdigital.ansible
+         - role: telusdigital.yo-dawg
 
 License
 -------


### PR DESCRIPTION
We have this package in ansible galaxy as telusdigital.yo-dawg. I updated the README to align.